### PR TITLE
Changes to allow Access-Control-Allow-Origin

### DIFF
--- a/chrome/content/code.js
+++ b/chrome/content/code.js
@@ -6,7 +6,7 @@ function Forcecors() {
 				var httpChannel = subject.QueryInterface(Components.interfaces.nsIHttpChannel);
 				var headers = Forcecors.getHeaders();
 				for(var i = 0; i < headers.length; i++) {
-					var keyValue = headers[i].split(':');
+					var keyValue = headers[i].split(' ');
 					httpChannel.setResponseHeader(keyValue[0], keyValue[1], false);
 				}
 			}
@@ -19,7 +19,7 @@ Forcecors.getHeaders = function() {
 		.getService(Components.interfaces.nsIPrefBranch);
 	var headers = prefs.getCharPref('forcecors.headers');
 	if(headers != null) {
-		return headers.split(' ');
+		return headers.split('|');
 	}
 	return [];
 };

--- a/defaults/preferences/forcecors.js
+++ b/defaults/preferences/forcecors.js
@@ -1,1 +1,1 @@
-pref('forcecors.headers', 'Access-Control-Allow-Origin:* Access-Control-Allow-Methods:POST,GET');
+pref('forcecors.headers', 'Access-Control-Allow-Credentials true|Access-Control-Allow-Origin http://127.0.0.1:8000|Access-Control-Allow-Methods POST,GET');

--- a/install.rdf
+++ b/install.rdf
@@ -3,14 +3,14 @@
      xmlns:em="http://www.mozilla.org/2004/em-rdf#">
 	<Description about="urn:mozilla:install-manifest">
 		<em:id>forcecors@ocact.us</em:id>
-		<em:version>1.3</em:version>
+		<em:version>1.4</em:version>
 		<em:type>2</em:type>
 	
 		<em:targetApplication>
 			<Description>
 				<em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
 				<em:minVersion>1.5</em:minVersion>
-				<em:maxVersion>9.0a1</em:maxVersion>
+				<em:maxVersion>19.0a1</em:maxVersion>
 			</Description>
 		</em:targetApplication> 
 	


### PR DESCRIPTION
Small change that allows to define a 'Access-Control-Allow-Origin' header, but we have to change a bit the logic. See commits messages for description.
